### PR TITLE
Add support for Symfony 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 7.4
+      env: COMPOSER_UPDATE_FLAGS='--prefer-lowest --prefer-stable'
 
       # Ignore the platform requirements for the upcoming PHP version
     - php: nightly
@@ -21,6 +23,7 @@ matrix:
 install:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev --no-interaction $COMPOSER_FLAGS
+  - if [[ -n "COMPOSER_UPDATE_FLAGS" ]]; then php composer.phar update $COMPOSER_UPDATE_FLAGS; fi 
 
 script:
   - mkdir -p build/logs;

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "require": {
         "json-mapper/json-mapper": "^1.0",
         "php": "^7.2 || ^8.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/config": "^5.0"
+        "symfony/http-kernel": "^4.4 | ^5.0",
+        "symfony/dependency-injection": "^4.4 | ^5.0",
+        "symfony/config": "^4.4 | ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,10 +29,10 @@
         }
     },
     "scripts": {
-        "phpcs": ["./vendor/bin/phpcs --standard=PSR12 src tests"],
-        "phpcbf": ["./vendor/bin/phpcbf --standard=PSR12 src tests"],
-        "phpstan": "./vendor/bin/phpstan analyse",
-        "unit-tests": "./vendor/bin/phpunit --testsuite unit --testdox --coverage-clover=build/logs/clover-unit-tests.xml"
+        "phpcs": "phpcs --standard=PSR12 src tests",
+        "phpcbf": "phpcbf --standard=PSR12 src tests",
+        "phpstan": "phpstan analyse",
+        "unit-tests": "phpunit --testsuite unit --testdox --coverage-clover=build/logs/clover-unit-tests.xml"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",


### PR DESCRIPTION
In this commit I have added Symfony 4.4 as an allowed dependency. I updated the Travis configuration to also run unit tests on Symfony 4.4.

I develop on Windows and to get the scripts running I had to remove the `./vendor/bin/` prefix from all scripts. Composer adds the bin directory to the PATH when it runs scripts, so this change has no influence on functionality.